### PR TITLE
Distinguish shortened pwd in prompt with ellipsis

### DIFF
--- a/share/functions/prompt_pwd.fish
+++ b/share/functions/prompt_pwd.fish
@@ -20,6 +20,6 @@ function prompt_pwd --description "Print the current working directory, shortene
         echo $tmp
     else
         # Shorten to at most $fish_prompt_pwd_dir_length characters per directory
-        string replace -ar '(\.?[^/]{'"$fish_prompt_pwd_dir_length"'})[^/]*/' '$1/' $tmp
+        string replace -ar '(\.?[^/]{'"$fish_prompt_pwd_dir_length"'})[^/]+/' '$1…/' $tmp
     end
 end


### PR DESCRIPTION
Before, it was not possible to tell from the prompt alone whether a path component got shortened, or it just happened to be exactly as long as `$fish_prompt_pwd_dir_length`.
At a small penalty, this change not only allows users to make that distinction, but also raises awareness for the shortening happening in the first place.